### PR TITLE
Update Baseline.ipynb

### DIFF
--- a/Baseline.ipynb
+++ b/Baseline.ipynb
@@ -348,7 +348,7 @@
     "                e = X_EMG[idx_emg][0]\n",
     "                f = X_IMG[idx_img]\n",
     "                \n",
-    "                mav = analyze(e, frame_len=0.2, frame_step=0.1, feat='MSV', preprocess=False)\n",
+    "                mav = analyze(e, frame_len=0.2, frame_step=0.1, feat='MAV', preprocess=False)\n",
     "                rms = analyze(e, frame_len=0.2, frame_step=0.1, feat='RMS', preprocess=False)\n",
     "                a = np.concatenate([mav, rms], 1)\n",
     "                \n",


### PR DESCRIPTION
I suppose this is a typo. Calling the analyze function with the argument 'MSV' does return an all zero matrix as far as I understand.